### PR TITLE
Improvements on the integration with the VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,24 @@
         "title": "Neo4j Cypher Runner: Select Environment"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "neo4j-cypher-runner.run-query",
+          "when": "editorLangId == cypher"
+        }
+      ]
+    },
     "configuration": [
       {
         "title": "Neo4j Cypher Runner",
         "properties": {
+          "neo4j-cypher-runner.showResultSummary": {
+            "type": "boolean",
+            "description": "Show summary object with the meta information about the query run in the result",
+            "title": "Show Result Summary",
+            "default": false
+          },
           "neo4j-cypher-runner.environments": {
             "type": "array",
             "title": "environments",
@@ -93,6 +107,9 @@
       }
     ]
   },
+  "extensionDependencies": [
+    "jakeboone02.cypher-query-language"
+  ],
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",

--- a/src/result-provider.ts
+++ b/src/result-provider.ts
@@ -1,0 +1,24 @@
+import { TextDocumentContentProvider, Uri } from 'vscode';
+
+
+export default class ResultProvider implements TextDocumentContentProvider {
+  private results: Map<string, string>;
+  private cursor: number;
+
+  constructor() {
+    this.results = new Map<string, string>();  
+    this.cursor = 0;
+  }
+
+  registerTextDocumentContent(content: string): string {
+    const key = `/${++this.cursor}/result.json`;
+    this.results.set(key, content);
+    return key;
+  }
+
+  provideTextDocumentContent(uri: Uri): string {
+    const result = this.results.get(uri.path) || "";
+    this.results.delete(uri.path);
+    return result;
+  }
+}


### PR DESCRIPTION
Showing the results using a provider TextDocumentContentProvider avoids a big number of unsaved documents open.

The `cypher` document filtering for the `Run Query` was moved clause when on the command palette, so the option is not shown when it isn't correct case. This is the reason why the extension depends on `jakeboone02.cypher-query-language`.

This change also adds a show result summary feature/option. It's configurable in the settings and it's useful for writing queries.